### PR TITLE
20200226更新

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -16,7 +16,7 @@ DEVICE_TYPE?=router
 DEFAULT_PACKAGES:=base-files libc libgcc busybox dropbear mtd uci opkg netifd fstools uclient-fetch logd urandom-seed urngd \
 block-mount coremark kmod-nf-nathelper kmod-nf-nathelper-extra kmod-ipt-raw wget libustream-openssl ca-certificates \
 default-settings luci luci-proto-relay luci-app-ddns luci-app-sqm luci-app-upnp luci-app-adbyby-plus luci-app-autoreboot \
-luci-app-filetransfer luci-app-vsftpd luci-app-ssr-plus luci-app-unblockneteasemusic-mini \
+luci-app-filetransfer luci-app-vsftpd luci-app-ssr-plus \
 luci-app-zerotier luci-app-arpbind luci-app-vlmcsd luci-app-wol luci-app-ramfree \
 luci-app-sfe luci-app-flowoffload luci-app-nlbwmon luci-app-accesscontrol \
 ddns-scripts_aliyun ddns-scripts_dnspod


### PR DESCRIPTION
1. XXR Plus: 加速在禁 ping 的服务器节点上启用的时间，从之前应用需要 10-20s 缩短到3秒内
2. XXR Plus: 修复官方的一个 lua 的 bug，这个会导致你订阅的机场节点全部更新后（名字和加密方式全换），节点被选择为 “禁用”而导致不能继续科学上网的问题
3. XXR Plus: 修复等于或超过 64 核心128线程的 CPU 上面，不能启动的问题