### PR TITLE
20201222 日常更新

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -8,11 +8,11 @@ endif
 
 LINUX_VERSION-4.14 = .195
 LINUX_VERSION-4.19 = .138
-LINUX_VERSION-5.4 = .83
+LINUX_VERSION-5.4 = .84
 
 LINUX_KERNEL_HASH-4.14.195 = 394f28798670240baacd9e2cce521fbd79f8da5e1fc191695b0e11381445a021
 LINUX_KERNEL_HASH-4.19.138 = d15c27d05f6c527269b75b30cc72972748e55720e7e00ad8abbaa4fe3b1d5e02
-LINUX_KERNEL_HASH-5.4.83 = beec970bbb93de8ab839f27930f7ab00c7bd65af0ffa07a50e765affdc2561c6
+LINUX_KERNEL_HASH-5.4.84 = 0985fcf6cdcebceca63cb70abab66d12e75fac61014a796ce71272b33f831515
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -38,6 +38,36 @@ endef
 
 # RK3399 boards
 
+define U-Boot/nanopi-r4s-1gb-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=NanoPi R4S 1GB
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-r4s-1gb
+  DEPENDS:=+PACKAGE_u-boot-nanopi-r4s-1gb-rk3399:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3399_bl31.elf
+endef
+
+define U-Boot/nanopi-r4s-4gb-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=NanoPi R4S 4GB
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-r4s-4gb
+  DEPENDS:=+PACKAGE_u-boot-nanopi-r4s-4gb-rk3399:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3399_bl31.elf
+endef
+
+define U-Boot/rock-pi-4-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=Rock Pi 4
+  BUILD_DEVICES:= \
+    radxa_rock-pi-4
+  DEPENDS:=+PACKAGE_u-boot-rock-pi-4-rk3399:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3399_bl31.elf
+endef
+
 define U-Boot/rockpro64-rk3399
   BUILD_SUBTARGET:=armv8
   NAME:=RockPro64
@@ -49,6 +79,9 @@ define U-Boot/rockpro64-rk3399
 endef
 
 UBOOT_TARGETS := \
+  nanopi-r4s-1gb-rk3399 \
+  nanopi-r4s-4gb-rk3399 \
+  rock-pi-4-rk3399 \
   rockpro64-rk3399 \
   nanopi-r2s-rk3328
 

--- a/package/boot/uboot-rockchip/patches/200-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/package/boot/uboot-rockchip/patches/200-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -1,0 +1,411 @@
+From 0aa583056cb1727fc09f4feca670d57634eb5605 Mon Sep 17 00:00:00 2001
+From: Tianling Shen <cnsztl@project-openwrt.eu.org>
+Date: Sat, 19 Dec 2020 11:49:33 +0000
+Subject: [PATCH] rockchip: rk3399: Add support for FriendlyARM NanoPi R4S
+
+This adds support for the NanoPi R4S from FriendlyArm.
+
+Rockchip RK3399 SoC
+1GB DDR3 or 4GB LPDDR4 RAM
+Gigabit Ethernet (WAN)
+Gigabit Ethernet (PCIe) (LAN)
+USB 3.0 Host Port x 2
+MicroSD slot
+Reset button
+WAN - LAN - SYS LED
+
+Signed-off-by: Tianling Shen <cnsztl@project-openwrt.eu.org>
+Co-authored-by: Marty Jones <mj8263788@gmail.com>
+Signed-off-by: Marty Jones <mj8263788@gmail.com>
+---
+ arch/arm/dts/Makefile                         |   2 +
+ .../arm/dts/rk3399-nanopi-r4s-1gb-u-boot.dtsi |   9 ++
+ arch/arm/dts/rk3399-nanopi-r4s-1gb.dts        |  27 +
+ .../arm/dts/rk3399-nanopi-r4s-4gb-u-boot.dtsi |   9 ++
+ arch/arm/dts/rk3399-nanopi-r4s-4gb.dts        |  27 +
+ arch/arm/dts/rk3399-nanopi-r4s.dtsi           | 122 ++++++++++++++++++
+ board/rockchip/evb_rk3399/MAINTAINERS         |  14 ++
+ configs/nanopi-r4s-1gb-rk3399_defconfig       |  61 ++++++++
+ configs/nanopi-r4s-4gb-rk3399_defconfig       |  62 ++++++++
+ 9 files changed, 333 insertions(+)
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s-1gb-u-boot.dtsi
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s-1gb.dts
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s-4gb-u-boot.dtsi
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s-4gb.dts
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s.dtsi
+ create mode 100644 configs/nanopi-r4s-1gb-rk3399_defconfig
+ create mode 100644 configs/nanopi-r4s-4gb-rk3399_defconfig
+
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -130,6 +130,8 @@ dtb-$(CONFIG_ROCKCHIP_RK3399) += \
+ 	rk3399-nanopi-m4.dtb \
+ 	rk3399-nanopi-m4-2gb.dtb \
+ 	rk3399-nanopi-neo4.dtb \
++	rk3399-nanopi-r4s-1gb.dtb \
++	rk3399-nanopi-r4s-4gb.dtb \
+ 	rk3399-orangepi.dtb \
+ 	rk3399-pinebook-pro.dtb \
+ 	rk3399-puma-haikou.dtb \
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s-1gb-u-boot.dtsi
+@@ -0,0 +1,9 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2018-2019 Rockchip Electronics Co., Ltd
++ * (C) Copyright 2020 Marty Jones <mj8263788@gmail.com>
++ * (C) Copyright 2020 Tianling Shen <cnsztl@project-openwrt.eu.org>
++ */
++
++#include "rk3399-nanopi4-u-boot.dtsi"
++#include "rk3399-sdram-ddr3-1600.dtsi"
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s-1gb.dts
+@@ -0,0 +1,27 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++#include "rk3399-nanopi-r4s.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPi R4S (1GB)";
++	compatible = "friendlyarm,nanopi-r4s-1gb", "rockchip,rk3399";
++};
++
++&leds {
++	/delete-node/ status;
++
++	lan_led: led-0 {
++		gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-1gb:green:lan";
++	};
++
++	sys_led: led-1 {
++ 		gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-1gb:red:sys";
++	};
++
++	wan_led: led-2 {
++		gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-1gb:green:wan";
++	};
++};
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s-4gb-u-boot.dtsi
+@@ -0,0 +1,9 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2018-2019 Rockchip Electronics Co., Ltd
++ * (C) Copyright 2020 Marty Jones <mj8263788@gmail.com>
++ * (C) Copyright 2020 Tianling Shen <cnsztl@project-openwrt.eu.org>
++ */
++
++#include "rk3399-nanopi4-u-boot.dtsi"
++#include "rk3399-sdram-lpddr4-100.dtsi"
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s-4gb.dts
+@@ -0,0 +1,27 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++#include "rk3399-nanopi-r4s.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPi R4S (4GB)";
++	compatible = "friendlyarm,nanopi-r4s-4gb", "rockchip,rk3399";
++};
++
++&leds {
++	/delete-node/ status;
++
++	lan_led: led-0 {
++		gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-4gb:green:lan";
++	};
++
++	sys_led: led-1 {
++ 		gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-4gb:red:sys";
++	};
++
++	wan_led: led-2 {
++		gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-4gb:green:wan";
++	};
++};
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s.dtsi
+@@ -0,0 +1,122 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Marty Jones <mj8263788@gmail.com>
++ * Copyright (c) 2020 Tianling Shen <cnsztl@project-openwrt.eu.org>
++ */
++
++/dts-v1/;
++#include "rk3399-nanopi4.dtsi"
++
++/ {
++	aliases {
++		led-boot = &sys_led;
++		led-failsafe = &sys_led;
++		led-running = &sys_led;
++		led-upgrade = &sys_led;
++		ethernet1 = &r8169;
++	};
++
++	vdd_5v: vdd-5v {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_5v";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		/* FIXME: adjust leveles for the connected fan */
++		cooling-levels = <0 12 18 255>;
++		#cooling-cells = <2>;
++		fan-supply = <&vdd_5v>;
++		pwms = <&pwm1 0 50000 0>;
++	};
++};
++
++&cpu_thermal {
++	trips {
++		cpu_warm: cpu_warm {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		cpu_hot: cpu_hot {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map2 {
++			trip = <&cpu_warm>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map3 {
++			trip = <&cpu_hot>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&emmc_phy {
++	status = "disabled";
++};
++
++&fusb0 {
++	status = "disabled";
++};
++
++&leds_gpio {
++	rockchip,pins =
++		<0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
++&pcie0 {
++	max-link-speed = <1>;
++	num-lanes = <1>;
++	vpcie3v3-supply = <&vcc3v3_sys>;
++
++	pcie@0 {
++		reg = <0x00000000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++
++		r8169: pcie@0,0 {
++			reg = <0x000000 0 0 0 0>;
++			local-mac-address = [ 00 00 00 00 00 00 ];
++		};
++	};
++};
++
++&sdhci {
++	status = "disabled";
++};
++
++&sdio0 {
++	status = "disabled";
++};
++
++&sdmmc {
++	host-index-min = <1>;
++};
++
++&u2phy0_host {
++	phy-supply = <&vdd_5v>;
++};
++
++&u2phy1_host {
++	status = "disabled";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "host";
++};
++
++&vcc3v3_sys {
++	vin-supply = <&vcc5v0_sys>;
++};
+--- a/board/rockchip/evb_rk3399/MAINTAINERS
++++ b/board/rockchip/evb_rk3399/MAINTAINERS
+@@ -55,6 +55,20 @@ S:	Maintained
+ F:	configs/nanopi-neo4-rk3399_defconfig
+ F:	arch/arm/dts/rk3399-nanopi-neo4-u-boot.dtsi
+ 
++NANOPI-R4S-1GB
++M:      Marty Jones <mj8263788@gmail.com>
++M:      Tianling Shen <cnsztl@project-openwrt.eu.org>
++S:      Maintained
++F:      configs/nanopi-r4s-1gb-rk3399_defconfig
++F:      arch/arm/dts/rk3399-nanopi-r4s-1gb-u-boot.dtsi
++
++NANOPI-R4S-4GB
++M:      Marty Jones <mj8263788@gmail.com>
++M:      Tianling Shen <cnsztl@project-openwrt.eu.org>
++S:      Maintained
++F:      configs/nanopi-r4s-4gb-rk3399_defconfig
++F:      arch/arm/dts/rk3399-nanopi-r4s-4gb-u-boot.dtsi
++
+ ORANGEPI-RK3399
+ M:	Jagan Teki <jagan@amarulasolutions.com>
+ S:	Maintained
+--- /dev/null
++++ b/configs/nanopi-r4s-1gb-rk3399_defconfig
+@@ -0,0 +1,61 @@
++CONFIG_ARM=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SYS_TEXT_BASE=0x00200000
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_ROCKCHIP_RK3399=y
++CONFIG_TARGET_EVB_RK3399=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEBUG_UART_BASE=0xFF1A0000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-nanopi-r4s-1gb.dtb"
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_STACK_R_MALLOC_SIMPLE_LEN=0x10000
++CONFIG_TPL=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3399-nanopi-r4s-1gb"
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_DM_ETH=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_USB_HOST_ETHER=y
++CONFIG_USB_ETHER_ASIX=y
++CONFIG_USB_ETHER_ASIX88179=y
++CONFIG_USB_ETHER_MCS7830=y
++CONFIG_USB_ETHER_RTL8152=y
++CONFIG_USB_ETHER_SMSC95XX=y
++CONFIG_DM_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_VIDEO_ROCKCHIP=y
++CONFIG_DISPLAY_ROCKCHIP_HDMI=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y
+--- /dev/null
++++ b/configs/nanopi-r4s-4gb-rk3399_defconfig
+@@ -0,0 +1,62 @@
++CONFIG_ARM=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SYS_TEXT_BASE=0x00200000
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_ROCKCHIP_RK3399=y
++CONFIG_TARGET_EVB_RK3399=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEBUG_UART_BASE=0xFF1A0000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-nanopi-r4s-4gb.dtb"
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_STACK_R_MALLOC_SIMPLE_LEN=0x10000
++CONFIG_TPL=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3399-nanopi-r4s-4gb"
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_DM_ETH=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM_RK3399_LPDDR4=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_USB_HOST_ETHER=y
++CONFIG_USB_ETHER_ASIX=y
++CONFIG_USB_ETHER_ASIX88179=y
++CONFIG_USB_ETHER_MCS7830=y
++CONFIG_USB_ETHER_RTL8152=y
++CONFIG_USB_ETHER_SMSC95XX=y
++CONFIG_DM_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_VIDEO_ROCKCHIP=y
++CONFIG_DISPLAY_ROCKCHIP_HDMI=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y
+

--- a/package/lean/mt/drivers/mt7603e/Makefile
+++ b/package/lean/mt/drivers/mt7603e/Makefile
@@ -38,7 +38,6 @@ define KernelPackage/mt7603e
   TITLE:=MTK wifi AP driver
   DEPENDS:=@TARGET_ramips
   FILES:=$(PKG_BUILD_DIR)/mt7603_wifi_ap/mt7603e.ko
-  AUTOLOAD:=$(call AutoLoad,91,mt7603e)
   SUBMENU:=Wireless Drivers
   MENU:=1
 endef

--- a/package/lean/mt/drivers/mt7612e/Makefile
+++ b/package/lean/mt/drivers/mt7612e/Makefile
@@ -26,7 +26,6 @@ define KernelPackage/mt76x2e
   TITLE:=MTK MT76x2e wifi AP driver
   DEPENDS:=@TARGET_ramips
   FILES:=$(PKG_BUILD_DIR)/mt76x2_ap/mt76x2_ap.ko
-  AUTOLOAD:=$(call AutoLoad,90,mt76x2_ap)
   SUBMENU:=Wireless Drivers
   MENU:=1
 endef

--- a/package/lean/mt/drivers/mt7615d/Makefile
+++ b/package/lean/mt/drivers/mt7615d/Makefile
@@ -188,7 +188,7 @@ ifneq ($(CONFIG_MTK_WHNAT_SUPPORT), )
   AUTOLOAD:=$(call AutoProbe,mt_wifi mt_whnat)
 else
   FILES:=$(PKG_BUILD_DIR)/mt_wifi_ap/mt_wifi.ko
-  AUTOLOAD:=$(call AutoLoad,90,mt_wifi)
+  AUTOLOAD:=$(call AutoProbe,mt_wifi)
 endif
   SUBMENU:=Wireless Drivers
   MENU:=1

--- a/package/lean/mt/drivers/mt_wifi/Makefile
+++ b/package/lean/mt/drivers/mt_wifi/Makefile
@@ -42,6 +42,7 @@ define Package/mt_wifi/install
 	$(INSTALL_DIR) $(1)/lib/wifi/
 	$(INSTALL_DIR) $(1)/etc/wireless/mt7615/
 	$(INSTALL_DIR) $(1)/etc_ro/Wireless/RT2860AP/
+	$(INSTALL_DIR) $(1)/lib/preinit/
 ifeq ($(CONFIG_MTK_CHIP_MT7603E_MT7612E),y)
 	$(INSTALL_BIN) ./files/7603_7612-l1profile.dat $(1)/etc/wireless/l1profile.dat
 	$(INSTALL_BIN) ./files/mt7603.dat $(1)/etc/wireless/mt7615/mt7615.1.dat
@@ -65,6 +66,7 @@ endif
 	$(INSTALL_BIN) ./files/SingleSKU_BF.dat $(1)/etc_ro/Wireless/RT2860AP/
 	$(INSTALL_BIN) ./files/mt7615.lua $(1)/lib/wifi
 	$(INSTALL_BIN) ./files/firmware.sh $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/91_load_wifi.sh $(1)/lib/preinit/
 endef
 
 $(eval $(call BuildPackage,mt_wifi))

--- a/package/lean/mt/drivers/mt_wifi/files/91_load_wifi.sh
+++ b/package/lean/mt/drivers/mt_wifi/files/91_load_wifi.sh
@@ -1,0 +1,9 @@
+. /lib/functions.sh
+
+load_wifi() {
+	local kernel_version=$(uname -r)
+	[ -e "/lib/modules/$kernel_version/mt7603e.ko" ] && modprobe mt7603e
+	[ -e "/lib/modules/$kernel_version/mt76x2_ap.ko" ] && modprobe mt76x2_ap
+}
+
+boot_hook_add preinit_main load_wifi

--- a/target/linux/layerscape/patches-5.4/701-net-0149-soc-fsl-dpio-change-CENA-regs-to-be-cacheable.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0149-soc-fsl-dpio-change-CENA-regs-to-be-cacheable.patch
@@ -32,7 +32,7 @@ Signed-off-by: Haiying Wang <Haiying.Wang@nxp.com>
  struct dpio_priv {
  	struct dpaa2_io *io;
  };
-@@ -200,13 +205,11 @@ static int dpaa2_dpio_probe(struct fsl_m
+@@ -197,13 +202,11 @@ static int dpaa2_dpio_probe(struct fsl_m
  	if (dpio_dev->obj_desc.region_count < 3) {
  		/* No support for DDR backed portals, use classic mapping */
  		/*
@@ -50,7 +50,7 @@ Signed-off-by: Haiying Wang <Haiying.Wang@nxp.com>
  	} else {
  		desc.regs_cena = devm_memremap(dev, dpio_dev->regions[2].start,
  					resource_size(&dpio_dev->regions[2]),
-@@ -214,7 +217,7 @@ static int dpaa2_dpio_probe(struct fsl_m
+@@ -211,7 +214,7 @@ static int dpaa2_dpio_probe(struct fsl_m
  	}
  
  	if (IS_ERR(desc.regs_cena)) {

--- a/target/linux/layerscape/patches-5.4/817-spi-0003-MLK-21960-1-spi-fspi-enable-fspi-on-imx8qxp-and-imx8.patch
+++ b/target/linux/layerscape/patches-5.4/817-spi-0003-MLK-21960-1-spi-fspi-enable-fspi-on-imx8qxp-and-imx8.patch
@@ -35,7 +35,7 @@ Signed-off-by: Han Xu <han.xu@nxp.com>
  struct nxp_fspi {
  	void __iomem *iobase;
  	void __iomem *ahb_addr;
-@@ -1076,6 +1092,8 @@ static int nxp_fspi_resume(struct device
+@@ -1083,6 +1099,8 @@ static int nxp_fspi_resume(struct device
  
  static const struct of_device_id nxp_fspi_dt_ids[] = {
  	{ .compatible = "nxp,lx2160a-fspi", .data = (void *)&lx2160a_data, },

--- a/target/linux/layerscape/patches-5.4/817-spi-0004-MLK-21960-2-spi-fspi-dynamically-alloc-AHB-memory.patch
+++ b/target/linux/layerscape/patches-5.4/817-spi-0004-MLK-21960-2-spi-fspi-dynamically-alloc-AHB-memory.patch
@@ -76,7 +76,7 @@ Signed-off-by: Han Xu <han.xu@nxp.com>
  	} else {
  		if (op->data.nbytes && op->data.dir == SPI_MEM_DATA_OUT)
  			nxp_fspi_fill_txfifo(f, op);
-@@ -992,9 +1018,8 @@ static int nxp_fspi_probe(struct platfor
+@@ -999,9 +1025,8 @@ static int nxp_fspi_probe(struct platfor
  
  	/* find the resources - controller memory mapped space */
  	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "fspi_mmap");
@@ -88,7 +88,7 @@ Signed-off-by: Han Xu <han.xu@nxp.com>
  		goto err_put_ctrl;
  	}
  
-@@ -1073,6 +1098,9 @@ static int nxp_fspi_remove(struct platfo
+@@ -1080,6 +1105,9 @@ static int nxp_fspi_remove(struct platfo
  
  	mutex_destroy(&f->lock);
  

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
@@ -9,7 +9,9 @@ boardname="${board##*,}"
 board_config_update
 
 case $board in
-friendlyarm,nanopi-r2s)
+friendlyarm,nanopi-r2s|\
+friendlyarm,nanopi-r4s-1gb|\
+friendlyarm,nanopi-r4s-4gb)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
 	;;

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -8,7 +8,9 @@ rockchip_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
-	friendlyarm,nanopi-r2s)
+	friendlyarm,nanopi-r2s|\
+	friendlyarm,nanopi-r4s-1gb|\
+	friendlyarm,nanopi-r4s-4gb)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;
 	*)
@@ -28,6 +30,11 @@ rockchip_setup_macs()
 	friendlyarm,nanopi-r2s)
 		wan_mac=$(macaddr_random)
 		lan_mac=$(macaddr_add "$wan_mac" +1)
+		;;
+	friendlyarm,nanopi-r4s-1gb|\
+	friendlyarm,nanopi-r4s-4gb)
+		lan_mac=$(cat /sys/class/net/eth1/address)
+		wan_mac=$(macaddr_random)
 		;;
 	esac
 

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -26,5 +26,10 @@ friendlyarm,nanopi-r2s)
 	set_interface_core 2 "eth0"
 	set_interface_core 4 "eth1" "xhci-hcd:usb3"
 	;;
+friendlyarm,nanopi-r4s-1gb|\
+friendlyarm,nanopi-r4s-4gb)
+	set_interface_core 10 "eth0"
+	set_interface_core 20 "eth1"
+	;;
 esac
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -15,6 +15,28 @@ define Device/friendlyarm_nanopi-r2s
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r2s
 
+define Device/friendlyarm_nanopi-r4s
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi R4S
+  SOC := rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script nanopi-r4s | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := kmod-r8169
+endef
+
+define Device/friendlyarm_nanopi-r4s-1gb
+  $(Device/friendlyarm_nanopi-r4s)
+  DEVICE_MODEL += 1GB
+  UBOOT_DEVICE_NAME := nanopi-r4s-1gb-rk3399
+endef
+TARGET_DEVICES += friendlyarm_nanopi-r4s-1gb
+
+define Device/friendlyarm_nanopi-r4s-4gb
+  $(Device/friendlyarm_nanopi-r4s)
+  DEVICE_MODEL += 4GB
+  UBOOT_DEVICE_NAME := nanopi-r4s-4gb-rk3399
+endef
+TARGET_DEVICES += friendlyarm_nanopi-r4s-4gb
+
 define Device/pine64_rockpro64
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := RockPro64

--- a/target/linux/rockchip/image/nanopi-r4s.bootscript
+++ b/target/linux/rockchip/image/nanopi-r4s.bootscript
@@ -1,0 +1,8 @@
+part uuid mmc ${devnum}:2 uuid
+
+setenv bootargs "console=ttyS2,1500000 earlycon=uart8250,mmio32,0xff1a0000 root=PARTUUID=${uuid} rw rootwait"
+
+load mmc ${devnum}:1 ${fdt_addr_r} rockchip.dtb
+load mmc ${devnum}:1 ${kernel_addr_r} kernel.img
+
+booti ${kernel_addr_r} - ${fdt_addr_r}

--- a/target/linux/rockchip/patches-5.4/004-arm64-dts-rockchip-Add-txpbl-node-for-RK3399-RK3328.patch
+++ b/target/linux/rockchip/patches-5.4/004-arm64-dts-rockchip-Add-txpbl-node-for-RK3399-RK3328.patch
@@ -44,7 +44,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  		mdio {
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -288,6 +288,7 @@
+@@ -291,6 +291,7 @@
  		resets = <&cru SRST_A_GMAC>;
  		reset-names = "stmmaceth";
  		rockchip,grf = <&grf>;

--- a/target/linux/rockchip/patches-5.4/200-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/target/linux/rockchip/patches-5.4/200-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -1,0 +1,226 @@
+From e46d311ad024821f4c892fead65e5b157fb98a6b Mon Sep 17 00:00:00 2001
+From: Tianling Shen <cnsztl@project-openwrt.eu.org>
+Date: Sat, 19 Dec 2020 11:57:26 +0000
+Subject: [PATCH] rockchip: rk3399: Add support for FriendlyARM NanoPi R4S
+
+This adds support for the NanoPi R4S from FriendlyArm.
+
+Rockchip RK3399 SoC
+1GB DDR3 or 4GB LPDDR4 RAM
+Gigabit Ethernet (WAN)
+Gigabit Ethernet (PCIe) (LAN)
+USB 3.0 Host Port x 2
+MicroSD slot
+Reset button
+WAN - LAN - SYS LED
+
+Signed-off-by: Tianling Shen <cnsztl@project-openwrt.eu.org>
+Co-authored-by: Marty Jones <mj8263788@gmail.com>
+Signed-off-by: Marty Jones <mj8263788@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/Makefile         |   2 +
+ .../dts/rockchip/rk3399-nanopi-r4s-1gb.dts    |  27 +
+ .../dts/rockchip/rk3399-nanopi-r4s-4gb.dts    |  27 +
+ .../boot/dts/rockchip/rk3399-nanopi-r4s.dtsi  | 122 ++++++++++++++++++
+ 4 files changed, 178 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s-1gb.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s-4gb.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -25,6 +25,8 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-leez-p710.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopc-t4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-m4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-neo4.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-r4s-1gb.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-r4s-4gb.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-orangepi.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-puma-haikou.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-roc-pc.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s-1gb.dts
+@@ -0,0 +1,27 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++#include "rk3399-nanopi-r4s.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPi R4S (1GB)";
++	compatible = "friendlyarm,nanopi-r4s-1gb", "rockchip,rk3399";
++};
++
++&leds {
++	/delete-node/ status;
++
++	lan_led: led-0 {
++		gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-1gb:green:lan";
++	};
++
++	sys_led: led-1 {
++		gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-1gb:red:sys";
++	};
++
++	wan_led: led-2 {
++		gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-1gb:green:wan";
++	};
++};
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s-4gb.dts
+@@ -0,0 +1,27 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++#include "rk3399-nanopi-r4s.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPi R4S (4GB)";
++	compatible = "friendlyarm,nanopi-r4s-4gb", "rockchip,rk3399";
++};
++
++&leds {
++	/delete-node/ status;
++
++	lan_led: led-0 {
++		gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-4gb:green:lan";
++	};
++
++	sys_led: led-1 {
++		gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-4gb:red:sys";
++	};
++
++	wan_led: led-2 {
++		gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s-4gb:green:wan";
++	};
++};
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dtsi
+@@ -0,0 +1,122 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Marty Jones <mj8263788@gmail.com>
++ * Copyright (c) 2020 Tianling Shen <cnsztl@project-openwrt.eu.org>
++ */
++
++/dts-v1/;
++#include "rk3399-nanopi4.dtsi"
++
++/ {
++	aliases {
++		led-boot = &sys_led;
++		led-failsafe = &sys_led;
++		led-running = &sys_led;
++		led-upgrade = &sys_led;
++		ethernet1 = &r8169;
++	};
++
++	vdd_5v: vdd-5v {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_5v";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		/* FIXME: adjust leveles for the connected fan */
++		cooling-levels = <0 12 18 255>;
++		#cooling-cells = <2>;
++		fan-supply = <&vdd_5v>;
++		pwms = <&pwm1 0 50000 0>;
++	};
++};
++
++&cpu_thermal {
++	trips {
++		cpu_warm: cpu_warm {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		cpu_hot: cpu_hot {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map2 {
++			trip = <&cpu_warm>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map3 {
++			trip = <&cpu_hot>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&emmc_phy {
++	status = "disabled";
++};
++
++&fusb0 {
++	status = "disabled";
++};
++
++&leds_gpio {
++	rockchip,pins =
++		<0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
++&pcie0 {
++	max-link-speed = <1>;
++	num-lanes = <1>;
++	vpcie3v3-supply = <&vcc3v3_sys>;
++
++	pcie@0 {
++		reg = <0x00000000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++
++		r8169: pcie@0,0 {
++			reg = <0x000000 0 0 0 0>;
++			local-mac-address = [ 00 00 00 00 00 00 ];
++		};
++	};
++};
++
++&sdhci {
++	status = "disabled";
++};
++
++&sdio0 {
++	status = "disabled";
++};
++
++&sdmmc {
++	host-index-min = <1>;
++};
++
++&u2phy0_host {
++	phy-supply = <&vdd_5v>;
++};
++
++&u2phy1_host {
++	status = "disabled";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "host";
++};
++
++&vcc3v3_sys {
++	vin-supply = <&vcc5v0_sys>;
++};
+


### PR DESCRIPTION
1. 内核升级到 5.4.84
2. 修复 MTK76xx 系列闭源驱动在某些情况下和 FLOW 加速冲突的问题
3. ROCKCHIP： 增加了对 友善 R4S 的支持 （不稳定，随时崩）
4. x64: 为 AMD CPU/GPU 系列内核开启 SAM ( Resizable-BAR ) 支持
5. 稳定版 OpenWrt 同步新的软件，并修复编译问题
